### PR TITLE
Fix incorrect protocol bit width in SvcServerInfo

### DIFF
--- a/docs/classes/netsvc/svcserverinfo.mdx
+++ b/docs/classes/netsvc/svcserverinfo.mdx
@@ -9,7 +9,7 @@ Part of [Net/Svc](../netsvc) message.
 {/* @dem-gen-begin:SvcServerInfo */}
 | Name | Type | Size in bytes | Size in bits | Value |
 | --- | --- | --- | --- | --- |
-| Protocol | int | 1 | 8 | - |
+| Protocol | int | 2 | 16 | - |
 | ServerCount | int | 4 | 32 | - |
 | IsHltv | boolean | 0.125 | 1 | - |
 | IsDedicated | boolean | 0.125 | 1 | - |


### PR DESCRIPTION
The `protocol` field of `SvcServerInfo` is documented as being a 1-byte integer. This is wrong, it's a 2-byte integer. The pseudocode for this message is correct.